### PR TITLE
Clusterrolebinding is not being deployed for the manager

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - role.yaml
+- role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable


### PR DESCRIPTION
When using make deploy, the clusterrolebinding for the manager is not being installed.
This leads to the manager not working as it should be.

This PR fix this issue and add the role_binding.yaml file to the
RBAC kustomization's manifest.

Fixes: #1

Signed-off-by: Youssef Azrak yazrak.tech@gmail.com